### PR TITLE
Release/0.0.15

### DIFF
--- a/make_libmodbus.sh
+++ b/make_libmodbus.sh
@@ -7,7 +7,7 @@ cd ./libmodbus/
 # reset to patch commit number
 git reset --hard 79a7c1ea82e5bb2e13c8efc77cb3e8a6d7368c58
 
-patch -c -p2 < ../mt.patch
+# patch -c -p2 < ../mt.patch
 
 #./autogen.sh && ./configure --enable-static=yes --enable-shared=no && make
 ./autogen.sh && ./configure && make

--- a/make_libmodbus.sh
+++ b/make_libmodbus.sh
@@ -5,7 +5,7 @@ git clone https://github.com/stephane/libmodbus.git
 cd ./libmodbus/
 
 # reset to patch commit number
-git reset --hard 79a7c1ea82e5bb2e13c8efc77cb3e8a6d7368c58
+git reset --hard f935846
 
 # patch -c -p2 < ../mt.patch
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modbus",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "libmodbus binding",
   "keywords": [
     "modbus"


### PR DESCRIPTION
Now we have support of libmodbus 3.1.4. It's probably unstable release (both for libmodbus and nodejs_libmodbus), so please, if you can - check everything.

P.S. tested on node.js 6.2.0